### PR TITLE
Support for Typescript compatible output with strict type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Do not fail when file from fileList doesn't exist or can not be loaded. When opt
 ```-m, --module-name```
 Name of the module to import in your application. 'templates' is default module name.
 
+```--service-type [service type]```
+The Typescript type of the AngularJS $templateCache service, to generate a file compliant with strict Typescript settings.
+
 ``` --no-html-min ```
 Will disable html minification (https://github.com/kangax/html-minifier).
 All Options prefixed with ```--htmlmin-``` will be passed directly to html-minifier. For example: ```--htmlmin-minifyCSS``` will be passed as ```minifyCSS``` option to html-minifier.

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -29,6 +29,8 @@ program
 
 	.option('--quotmark [quotmark]', 'quotation mark to use. [\'|"] [sing quote|double quote]. single quote by default', '\'')
 	.option('--whitespace [whitespace]', 'whitespace type. [tabs|spaces]. tabs is default.', 'tabs')
+	
+	.option('--service-type [Typescript type]', 'The Typescript type of the AngularJS $templateCache service, to output file compliant with strict TS')
 
 	.allowUnknownOption(true);
 
@@ -51,6 +53,7 @@ var options = _.defaults({
 	style: program.style,
 	header: program.header,
 	moduleName: program.moduleName,
+	serviceType: program.serviceType,
 	newModule: program.newModule,
 	basePath: program.basePath,
 	qutomark: program.quotmark,

--- a/lib/templateGenerator.js
+++ b/lib/templateGenerator.js
@@ -18,11 +18,15 @@ function wrapInTemplateCache(options, entries) {
 		return quotmark + string + quotmark;
 	}
 
+	function createServiceType() {
+		return (options.serviceType) ? (': ' + options.serviceType) : '';
+	}
+
 	function createContentPrefix() {
 		var maybeNewModule = options.newModule ? ', []' : '';
 		return selectAngularImportStyle(options.style) +
 			whitespace + '.module(' + quote(options.moduleName) + maybeNewModule + ')\n' +
-			whitespace + '.run([' + quote('$templateCache') + ', function($templateCache) {';
+			whitespace + '.run([' + quote('$templateCache') + ', function($templateCache' + createServiceType() + ') {';
 	}
 
 	function createContentSuffix() {

--- a/test/templateGenerator.spec.js
+++ b/test/templateGenerator.spec.js
@@ -103,6 +103,30 @@ describe('templateGenerator.spec.js', function () {
 		});
 	});
 
+	it('should use provided TS type', function (done) {
+		//given
+		var options = {serviceType: 'ng.ITemplateCacheService'};
+		var generator = templateGenerator(_.defaults(options, defaults));
+
+		//when
+		generator([])
+
+		//then
+			.then(function (result) {
+				expect(result).to.eql(
+					[
+						useStrictString +
+						defaultHeaderString +
+						browserAngular +
+						defaultModuleString +
+						'\t.run([\'$templateCache\', function($templateCache: ng.ITemplateCacheService) {\n\n' +
+						browserSuffix
+					].join('')
+				);
+			})
+			.then(done);
+	});
+
 	it('should use provided module name', function (done) {
 		//given
 		var moduleName = 'my-html';


### PR DESCRIPTION
Hi,
Since the Typescript --allow-js option is still quite limited, it could be interesting to allow this tool to be able to output full-strict compliant TS code. The only thing missing so far is the possibility to specify the Angular type of the $templateCache service.
With this patch it is possible to specify a custom service type: this will be added in the output with the correct TS syntax.
Thank you,
 Luciano