### PR TITLE
Fix concatenation of basePath with the file path

### DIFF
--- a/lib/fileProcessor.js
+++ b/lib/fileProcessor.js
@@ -50,7 +50,7 @@ function executeHtmlMinification(options, html) {
 }
 
 function createEntry(basePath, file, fileContent) {
-	var filePath = file.replace(basePath, '');
+	var filePath = basePath.concat(file);
 	return {
 		path: filePath,
 		html: fileContent


### PR DESCRIPTION
Replace was being used previously which seems like a bug, the basePath was not added to the beginning of the file path